### PR TITLE
feat: Add support for custom Configuration models

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,45 @@ return [
 ];
 ```
 
+#### 2.8 Using Custom Configuration Models
+
+If you need to extend the Configuration model with additional functionality (e.g., soft deletes, auditing, or custom traits), you can use your own model class:
+
+**Step 1:** Create a custom model that extends the base Configuration model:
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Whilesmart\ModelConfiguration\Models\Configuration as BaseConfiguration;
+
+class Configuration extends BaseConfiguration
+{
+    use SoftDeletes;
+
+    protected $fillable = ['configurable_id', 'configurable_type', 'key', 'type', 'value', 'metadata'];
+}
+```
+
+**Step 2:** Configure the package to use your custom model:
+```php
+<?php
+
+return [
+    ...,
+    'model' => \App\Models\Configuration::class,
+];
+```
+
+**Step 3:** Use the package normally - no need to override traits or controllers!
+
+The package will automatically use your custom model for all configuration operations. This allows you to:
+- Add Laravel traits (SoftDeletes, Auditable, etc.)
+- Include additional attributes and relationships
+- Implement custom business logic at the model level
+- Receive automatic package updates without maintaining custom controllers
+
 ### 3. Model Relationships
 
 We have implemented a Trait `Configurable` that handles relationships. If your model has configuration, simply use the

--- a/config/model-configuration.php
+++ b/config/model-configuration.php
@@ -6,4 +6,5 @@ return [
     'auth_middleware' => [],
     'allow_case_insensitive_keys' => false,
     'allowed_keys' => [],
+    'model' => \Whilesmart\ModelConfiguration\Models\Configuration::class,
 ];

--- a/src/Traits/Configurable.php
+++ b/src/Traits/Configurable.php
@@ -17,7 +17,9 @@ trait Configurable
 
     public function configurations(): MorphMany
     {
-        return $this->morphMany(Configuration::class, 'configurable');
+        $model = config('model-configuration.model', Configuration::class);
+
+        return $this->morphMany($model, 'configurable');
     }
 
     public function getConfigValue(string $key)

--- a/workbench/app/Models/CustomConfiguration.php
+++ b/workbench/app/Models/CustomConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Workbench\App\Models;
+
+use Whilesmart\ModelConfiguration\Models\Configuration;
+
+class CustomConfiguration extends Configuration
+{
+    protected $table = 'configurations';
+
+    protected $appends = ['is_custom'];
+
+    public function getIsCustomAttribute(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Allow users to specify custom Configuration model class via config, enabling extension with traits (SoftDeletes, Syncable, etc.) without duplicating controllers or overriding package traits.

Users can now:
- Create custom model extending base Configuration
- Set 'model' option in config/model-configuration.php
- Receive automatic package updates (e.g., allowed_keys validation)

This eliminates the need to publish and maintain custom controllers for simple model extensions, reducing maintenance burden and ensuring users benefit from package improvements automatically.