### PR TITLE
fix: Support configurable for non integer id types

### DIFF
--- a/database/migrations/2025_06_30_120453_create_configurations_table.php
+++ b/database/migrations/2025_06_30_120453_create_configurations_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('key');
             $table->json('value');
             $table->string('configurable_type');
-            $table->unsignedBigInteger('configurable_id');
+            $table->string('configurable_id');
             $table->string('type')->default('string');
             $table->timestamps();
 


### PR DESCRIPTION
Change configurable_id from unsignedBigInteger to string to support UUIDs, ULIDs, and other non-integer primary key types.

Note: Existing installations must manually alter the column: ALTER TABLE configurations MODIFY configurable_id VARCHAR(255);