### PR TITLE
docs: Add documentation manifest and markdown files

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/whilesmart/docs-kit/main/schema/docs.schema.json",
+  "name": "Eloquent Model Configuration",
+  "description": "Laravel package for managing model-specific configurations with type safety, polymorphic relationships, and ready-to-use API endpoints",
+  "icon": "database",
+  "category": {
+    "language": "php",
+    "framework": "laravel"
+  },
+  "sidebar": [
+    { "title": "Installation", "path": "docs/installation.md" },
+    { "title": "Quick Start", "path": "docs/quick-start.md" },
+    { "title": "Configuration", "path": "docs/configuration.md" },
+    { "title": "Configurable Trait", "path": "docs/configurable-trait.md" },
+    { "title": "Value Types", "path": "docs/value-types.md" },
+    { "title": "API Endpoints", "path": "docs/api-endpoints.md" },
+    { "title": "Hooks", "path": "docs/hooks.md" },
+    { "title": "Custom Models", "path": "docs/custom-models.md" }
+  ]
+}

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,0 +1,174 @@
+# API Endpoints
+
+The package provides RESTful API endpoints for managing configurations.
+
+## Base URL
+
+Default: `/api/model-configurations`
+Configurable via `config('model-configuration.route_prefix')`.
+
+## Authentication
+
+All endpoints require authentication. Configure in `config/model-configuration.php`:
+
+```php
+'auth_middleware' => ['auth:sanctum'],
+```
+
+## Endpoints
+
+### List Configurations
+
+```
+GET /api/model-configurations
+```
+
+**Query Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `configurable_type` | Yes | FQCN of the model (e.g., `App\Models\User`) |
+| `configurable_id` | Yes | Model ID |
+
+**Example:**
+```
+GET /api/model-configurations?configurable_type=App\Models\User&configurable_id=1
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "key": "timezone",
+      "value": "America/New_York",
+      "type": "string",
+      "configurable_type": "App\\Models\\User",
+      "configurable_id": 1,
+      "created_at": "2024-01-15T10:30:00Z",
+      "updated_at": "2024-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+### Get Single Configuration
+
+```
+GET /api/model-configurations/{key}
+```
+
+**Query Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `configurable_type` | Yes | FQCN of the model |
+| `configurable_id` | Yes | Model ID |
+
+**Example:**
+```
+GET /api/model-configurations/timezone?configurable_type=App\Models\User&configurable_id=1
+```
+
+### Create Configuration
+
+```
+POST /api/model-configurations
+```
+
+**Body (JSON):**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `key` | Yes | Configuration key |
+| `value` | Yes | Configuration value |
+| `type` | Yes | One of: `string`, `int`, `float`, `bool`, `array`, `json`, `date` |
+| `configurable_type` | Yes | FQCN of the model |
+| `configurable_id` | Yes | Model ID |
+
+**Example:**
+```json
+POST /api/model-configurations
+{
+    "key": "theme",
+    "value": "dark",
+    "type": "string",
+    "configurable_type": "App\\Models\\User",
+    "configurable_id": 1
+}
+```
+
+### Update Configuration
+
+```
+PUT /api/model-configurations/{key}
+```
+
+**Body (JSON):** Same as create.
+
+**Example:**
+```json
+PUT /api/model-configurations/theme
+{
+    "value": "light",
+    "type": "string",
+    "configurable_type": "App\\Models\\User",
+    "configurable_id": 1
+}
+```
+
+### Delete Configuration
+
+```
+DELETE /api/model-configurations/{key}
+```
+
+**Query Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `configurable_type` | Yes | FQCN of the model |
+| `configurable_id` | Yes | Model ID |
+
+**Example:**
+```
+DELETE /api/model-configurations/theme?configurable_type=App\Models\User&configurable_id=1
+```
+
+## OpenAPI Documentation
+
+The package includes OpenAPI attributes on the controller. To expose:
+
+1. Publish docs:
+   ```bash
+   php artisan vendor:publish --tag=model-configuration-docs
+   ```
+
+2. Install `zircote/swagger-php` (included in require-dev)
+
+3. Generate OpenAPI spec:
+   ```bash
+   ./vendor/bin/openapi --output storage/api-docs
+   ```
+
+## Validation Rules
+
+### Allowed Keys
+If `allowed_keys` is configured, only those keys can be created/updated.
+
+### Case Sensitivity
+If `allow_case_insensitive_keys` is true, key lookups are case-insensitive.
+
+### Type Validation
+The `type` field must be one of the supported enum values.
+
+## Error Responses
+
+| Status | Scenario |
+|--------|----------|
+| 401 | Unauthenticated |
+| 403 | Key not in `allowed_keys` |
+| 404 | Configuration not found |
+| 422 | Validation failed (missing fields, invalid type) |
+| 500 | Server error |

--- a/docs/configurable-trait.md
+++ b/docs/configurable-trait.md
@@ -1,0 +1,110 @@
+# Configurable Trait
+
+The `Configurable` trait provides all methods for managing model configurations.
+
+## Usage
+
+```php
+use Whilesmart\ModelConfiguration\Traits\Configurable;
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+
+class User extends Model
+{
+    use Configurable;
+}
+```
+
+## Methods
+
+### `configurations()`
+
+Returns the MorphMany relationship to configurations.
+
+```php
+$user->configurations()->get();
+$user->configurations()->where('key', 'theme')->first();
+```
+
+### `getConfig(string $key): ?Configuration`
+
+Returns the full Configuration model for a key.
+
+```php
+$config = $user->getConfig('timezone');
+
+if ($config) {
+    $config->key;       // "timezone"
+    $config->value;     // "America/New_York"
+    $config->type;      // "string"
+    $config->metadata;  // additional data (if any)
+}
+```
+
+### `getConfigValue(string $key): mixed`
+
+Returns the typed value of a configuration. Automatically casts based on stored type.
+
+```php
+$timezone = $user->getConfigValue('timezone');        // string
+$perPage  = $user->getConfigValue('posts_per_page');  // int
+$enabled  = $user->getConfigValue('notifications');   // bool
+$prefs    = $user->getConfigValue('preferences');     // array
+$layout   = $user->getConfigValue('dashboard_layout'); // object/array
+$date     = $user->getConfigValue('trial_ends_at');   // Carbon|null
+```
+
+Returns `null` if key doesn't exist or type parsing fails.
+
+### `getConfigType(string $key): ?ConfigValueType`
+
+Returns the ConfigValueType enum for a key.
+
+```php
+$type = $user->getConfigType('timezone'); // ConfigValueType::String
+$type = $user->getConfigType('per_page'); // ConfigValueType::Integer
+```
+
+### `setConfigValue(string $key, mixed $value, ConfigValueType $type): Configuration`
+
+Creates or updates a configuration value. Returns the Configuration model.
+
+```php
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+
+$user->setConfigValue('theme', 'dark', ConfigValueType::String);
+$user->setConfigValue('per_page', 50, ConfigValueType::Integer);
+$user->setConfigValue('debug_mode', true, ConfigValueType::Boolean);
+$user->setConfigValue('tags', ['laravel', 'php'], ConfigValueType::Array);
+$user->setConfigValue('settings', ['foo' => 'bar'], ConfigValueType::Json);
+$user->setConfigValue('expires_at', now()->addMonth(), ConfigValueType::Date);
+```
+
+### `getConfigurationsAttribute()`
+
+Returns all configurations as a collection. Automatically available when `$appends` includes `configurations`.
+
+```php
+class User extends Model
+{
+    use Configurable;
+    protected $appends = ['configurations'];
+}
+
+$user->configurations; // Collection of Configuration models
+```
+
+## Hook Integration
+
+The trait automatically runs registered hooks when `setConfigValue()` is called. See [Hooks](hooks.md).
+
+## Polymorphic Relationship
+
+The trait uses a polymorphic relationship, so any model can use it:
+
+```php
+class Team extends Model { use Configurable; }
+class Project extends Model { use Configurable; }
+class Setting extends Model { use Configurable; }
+```
+
+Each model gets its own configurations table entries via `configurable_type` and `configurable_id`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,132 @@
+# Configuration
+
+## Publish Config
+
+```bash
+php artisan vendor:publish --tag=model-configuration
+```
+
+Creates `config/model-configuration.php`:
+
+```php
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Register Routes
+    |--------------------------------------------------------------------------
+    |
+    | Whether to automatically register the package routes.
+    | Set to false if you want to manually define routes.
+    |
+    */
+    'register_routes' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route Prefix
+    |--------------------------------------------------------------------------
+    |
+    | The URL prefix for all package routes.
+    | Default: 'api' (routes at /api/model-configurations)
+    |
+    */
+    'route_prefix' => env('MODEL_CONFIG_ROUTE_PREFIX', 'api'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auth Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Middleware to protect the configuration endpoints.
+    | Must be an array of middleware names.
+    |
+    */
+    'auth_middleware' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allow Case-Insensitive Keys
+    |--------------------------------------------------------------------------
+    |
+    | If true, config keys are case-insensitive.
+    | 'ConfigName' and 'configname' are treated as the same key.
+    |
+    */
+    'allow_case_insensitive_keys' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Keys
+    |--------------------------------------------------------------------------
+    |
+    | Restrict which config keys can be used.
+    | Empty array = all keys allowed.
+    |
+    | Each entry can be:
+    | - A string key name (no validation)
+    | - Key => Laravel validation rules
+    |
+    */
+    'allowed_keys' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Configuration Model
+    |--------------------------------------------------------------------------
+    |
+    | Use a custom model extending the base Configuration model.
+    | Enables adding traits like SoftDeletes, Auditable, etc.
+    |
+    */
+    'model' => \Whilesmart\ModelConfiguration\Models\Configuration::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Hooks
+    |--------------------------------------------------------------------------
+    |
+    | Register hooks to customize behavior. Each hook class can implement:
+    | - ModelHookInterface: runs before/after HTTP requests
+    | - ConfigValueHookInterface: runs when setConfigValue() is called
+    |
+    | A single hook class can implement both interfaces.
+    |
+    */
+    'hooks' => [],
+];
+```
+
+## Environment Variables
+
+```env
+# Optional: Change route prefix
+MODEL_CONFIG_ROUTE_PREFIX=api
+```
+
+## Allowed Keys Examples
+
+```php
+// Allow specific keys only (no validation)
+'allowed_keys' => ['timezone', 'theme', 'posts_per_page'],
+
+// Allow with validation rules
+'allowed_keys' => [
+    'timezone' => 'string|in:UTC,America/New_York,Europe/London',
+    'posts_per_page' => 'integer|min:1|max:100',
+    'theme' => 'string|in:light,dark,auto',
+    'simple_key', // No validation
+],
+
+// Allow all (default)
+'allowed_keys' => [],
+```
+
+## Case-Insensitive Keys
+
+When `'allow_case_insensitive_keys' => true`:
+- Keys are stored as-is (case preserved)
+- Lookups are case-insensitive
+- `getConfig('TimeZone')` finds key `'timezone'`
+- `getConfig('TIMEZONE')` finds key `'timezone'`

--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -1,0 +1,150 @@
+# Custom Configuration Models
+
+Extend the base Configuration model to add features like soft deletes, auditing, or custom traits.
+
+## Step 1: Create Custom Model
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Whilesmart\ModelConfiguration\Models\Configuration as BaseConfiguration;
+
+class Configuration extends BaseConfiguration
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'configurable_id',
+        'configurable_type',
+        'key',
+        'type',
+        'value',
+        'metadata',
+    ];
+
+    // Add custom relationships, accessors, scopes, etc.
+}
+```
+
+## Step 2: Configure Package
+
+In `config/model-configuration.php`:
+
+```php
+return [
+    // ...
+    'model' => \App\Models\Configuration::class,
+];
+```
+
+## Step 3: Publish and Modify Migrations
+
+```bash
+php artisan vendor:publish --tag=model-configuration-migrations
+```
+
+Edit the migration to add `deleted_at` column:
+
+```php
+Schema::create('configurations', function (Blueprint $table) {
+    $table->id();
+    $table->string('key');
+    $table->json('value');
+    $table->string('configurable_type');
+    $table->unsignedBigInteger('configurable_id');
+    $table->string('type')->default('string');
+    $table->softDeletes(); // Add this line
+    $table->timestamps();
+
+    $table->unique(['configurable_id', 'configurable_type', 'key']);
+});
+```
+
+```bash
+php artisan migrate
+```
+
+## Features Enabled
+
+### Soft Deletes
+```php
+$user->setConfigValue('theme', 'dark', ConfigValueType::String);
+
+// Soft delete
+$user->configurations()->where('key', 'theme')->delete();
+
+// Restore
+$user->configurations()->withTrashed()->where('key', 'theme')->restore();
+
+// Query with trashed
+$user->configurations()->withTrashed()->get();
+```
+
+### Auditing (spatie/laravel-activitylog)
+```php
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class Configuration extends BaseConfiguration
+{
+    use LogsActivity;
+
+    protected static $logAttributes = ['key', 'value', 'type'];
+    protected static $logOnlyDirty = true;
+    protected static $submitEmptyLogs = false;
+}
+```
+
+### Custom Traits
+```php
+class Configuration extends BaseConfiguration
+{
+    use HasUuid, HasTeam, HasFactory;
+
+    // Custom methods
+    public function scopeForUser($query, User $user)
+    {
+        return $query->where('configurable_type', User::class)
+            ->where('configurable_id', $user->id);
+    }
+}
+```
+
+### Additional Columns
+Add columns to the migration and model:
+
+```php
+// Migration
+$table->string('description')->nullable();
+$table->boolean('is_system')->default(false);
+
+// Model
+protected $fillable = [
+    'configurable_id',
+    'configurable_type',
+    'key',
+    'type',
+    'value',
+    'metadata',
+    'description',
+    'is_system',
+];
+```
+
+## Benefits
+
+- No need to override controllers or routes
+- Package automatically uses your custom model
+- Receive package updates without maintaining custom controllers
+- Full Laravel model capabilities (observers, events, scopes, etc.)
+
+## Testing
+
+```php
+// Verify custom model is used
+$config = $user->setConfigValue('test', 'value', ConfigValueType::String);
+assert($config instanceof \App\Models\Configuration);
+assert($config->trashed() === false);
+```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,164 @@
+# Hooks
+
+Hooks allow customizing package behavior at two extension points.
+
+## Hook Types
+
+### 1. ModelHookInterface (HTTP Request Hooks)
+
+Runs before/after HTTP requests to configuration endpoints.
+
+```php
+use Whilesmart\ModelConfiguration\Interfaces\ModelHookInterface;
+use Whilesmart\ModelConfiguration\Enums\ConfigAction;
+use Illuminate\Http\Request;
+
+class PaginateResultsHook implements ModelHookInterface
+{
+    public function beforeQuery(mixed $data, ConfigAction $action, Request $request): mixed
+    {
+        if ($action === ConfigAction::INDEX) {
+            return $data->paginate(20);
+        }
+        return $data;
+    }
+
+    public function afterQuery(mixed $results, ConfigAction $action, Request $request): mixed
+    {
+        return $results;
+    }
+}
+```
+
+**Actions:**
+- `ConfigAction::INDEX` — List configurations
+- `ConfigAction::STORE` — Create configuration
+- `ConfigAction::SHOW` — Get single configuration
+- `ConfigAction::UPDATE` — Update configuration
+- `ConfigAction::DESTROY` — Delete configuration
+
+### 2. ConfigValueHookInterface (Value Change Hooks)
+
+Runs when `setConfigValue()` is called (both via trait and API).
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+use Whilesmart\ModelConfiguration\Interfaces\ConfigValueHookInterface;
+use Whilesmart\ModelConfiguration\Models\Configuration;
+
+class OnboardingCompletedHook implements ConfigValueHookInterface
+{
+    public function onConfigValueSet(
+        Model $model,
+        string $key,
+        mixed $value,
+        ConfigValueType $type,
+        Configuration $configuration,
+        bool $wasCreated
+    ): void {
+        if ($key === 'onboarding_completed' && $value === 'true') {
+            app(OnboardingService::class)->complete($model);
+        }
+    }
+}
+```
+
+**Parameters:**
+- `$model` — The configurable model (e.g., User)
+- `$key` — Configuration key that was set
+- `$value` — New value
+- `$type` — ConfigValueType enum
+- `$configuration` — Configuration model instance
+- `$wasCreated` — True if new, false if updated
+
+### 3. Combined Hook
+
+A single class can implement both interfaces:
+
+```php
+use Whilesmart\ModelConfiguration\Interfaces\ModelHookInterface;
+use Whilesmart\ModelConfiguration\Interfaces\ConfigValueHookInterface;
+use Whilesmart\ModelConfiguration\Enums\ConfigAction;
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Model;
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+use Whilesmart\ModelConfiguration\Models\Configuration;
+
+class MyHook implements ModelHookInterface, ConfigValueHookInterface
+{
+    // ModelHookInterface
+    public function beforeQuery(mixed $data, ConfigAction $action, Request $request): mixed
+    {
+        return $data;
+    }
+
+    public function afterQuery(mixed $results, ConfigAction $action, Request $request): mixed
+    {
+        return $results;
+    }
+
+    // ConfigValueHookInterface
+    public function onConfigValueSet(
+        Model $model,
+        string $key,
+        mixed $value,
+        ConfigValueType $type,
+        Configuration $configuration,
+        bool $wasCreated
+    ): void {
+        // Handle value changes
+    }
+}
+```
+
+## Registering Hooks
+
+Add to `config/model-configuration.php`:
+
+```php
+return [
+    // ...
+    'hooks' => [
+        \App\Hooks\PaginateResultsHook::class,
+        \App\Hooks\OnboardingCompletedHook::class,
+        \App\Hooks\MyCombinedHook::class,
+    ],
+];
+```
+
+Hooks are resolved via Laravel's container (supports constructor injection).
+
+## Use Cases
+
+| Hook Type | Use Cases |
+|-----------|-----------|
+| ModelHookInterface | Pagination, filtering, response transformation, logging, rate limiting |
+| ConfigValueHookInterface | Trigger side effects, sync to external services, audit logging, notifications, cache invalidation |
+
+## Example: Audit Log Hook
+
+```php
+class AuditConfigHook implements ConfigValueHookInterface
+{
+    public function onConfigValueSet(
+        Model $model,
+        string $key,
+        mixed $value,
+        ConfigValueType $type,
+        Configuration $configuration,
+        bool $wasCreated
+    ): void {
+        activity()
+            ->causedBy(auth()->user())
+            ->performedOn($model)
+            ->withProperties([
+                'config_key' => $key,
+                'old_value' => $wasCreated ? null : $configuration->getOriginal('value'),
+                'new_value' => $value,
+                'type' => $type->value,
+            ])
+            ->log($wasCreated ? 'config_created' : 'config_updated');
+    }
+}
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,74 @@
+# Installation
+
+## Requirements
+
+- PHP 8.1+
+- Laravel 10.x or 11.x
+- Laravel Sanctum (for API authentication)
+
+## Install via Composer
+
+```bash
+composer require whilesmart/eloquent-model-configuration
+```
+
+The service provider is auto-discovered.
+
+## Publish and Migrate
+
+### Publish Everything (Recommended)
+
+```bash
+php artisan vendor:publish --tag=model-configuration
+php artisan migrate
+```
+
+This publishes:
+- Migrations → `database/migrations/`
+- Routes → `routes/model-configuration.php`
+- Controllers → `app/Http/Controllers/`
+- Config → `config/model-configuration.php`
+
+### Publish Selectively
+
+**Routes only:**
+```bash
+php artisan vendor:publish --tag=model-configuration-routes
+```
+
+**Migrations only:**
+```bash
+php artisan vendor:publish --tag=model-configuration-migrations
+```
+
+**Controllers only:**
+```bash
+php artisan vendor:publish --tag=model-configuration-controllers
+```
+
+**Documentation (OpenAPI):**
+```bash
+php artisan vendor:publish --tag=model-configuration-docs
+```
+
+## Register Routes
+
+After publishing routes, add to your `routes/api.php`:
+
+```php
+require base_path('routes/model-configuration.php');
+```
+
+## Configure Auth Middleware
+
+Edit `config/model-configuration.php`:
+
+```php
+return [
+    // ...
+    'auth_middleware' => ['auth:sanctum'],
+    // ...
+];
+```
+
+The default routes require authentication.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,93 @@
+# Quick Start
+
+## 1. Add Trait to Your Model
+
+```php
+use Whilesmart\ModelConfiguration\Traits\Configurable;
+
+class User extends Model
+{
+    use Configurable;
+}
+```
+
+## 2. Run Migrations
+
+```bash
+php artisan migrate
+```
+
+## 3. Set Configuration Values
+
+```php
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+
+$user = User::find(1);
+
+// String value
+$user->setConfigValue('timezone', 'America/New_York', ConfigValueType::String);
+
+// Integer value
+$user->setConfigValue('posts_per_page', 25, ConfigValueType::Integer);
+
+// Boolean value
+$user->setConfigValue('notifications_enabled', true, ConfigValueType::Boolean);
+
+// Array value
+$user->setConfigValue('preferences', ['theme' => 'dark', 'lang' => 'en'], ConfigValueType::Array);
+
+// JSON value (complex objects)
+$user->setConfigValue('dashboard_layout', ['widgets' => ['stats', 'charts']], ConfigValueType::Json);
+
+// Date value
+$user->setConfigValue('trial_ends_at', now()->addDays(14), ConfigValueType::Date);
+```
+
+## 4. Get Configuration Values
+
+```php
+// Get typed value (returns correct PHP type)
+$timezone = $user->getConfigValue('timezone'); // string
+$perPage = $user->getConfigValue('posts_per_page'); // int
+$enabled = $user->getConfigValue('notifications_enabled'); // bool
+
+// Get raw configuration model
+$config = $user->getConfig('timezone');
+$config->key;     // "timezone"
+$config->value;   // "America/New_York"
+$config->type;    // "string"
+
+// Check if config exists
+if ($user->getConfig('timezone')) {
+    // ...
+}
+```
+
+## 5. Access via API
+
+### Get all configurations for a model
+```
+GET /api/model-configurations?configurable_type=App\Models\User&configurable_id=1
+```
+
+### Get single configuration
+```
+GET /api/model-configurations/{key}?configurable_type=App\Models\User&configurable_id=1
+```
+
+### Create/Update configuration
+```
+POST /api/model-configurations
+{
+    "key": "theme",
+    "value": "dark",
+    "type": "string",
+    "configurable_type": "App\\Models\\User",
+    "configurable_id": 1
+}
+```
+
+### Delete configuration
+```
+DELETE /api/model-configurations/{key}?configurable_type=App\Models\User&configurable_id=1
+```

--- a/docs/value-types.md
+++ b/docs/value-types.md
@@ -1,0 +1,118 @@
+# Value Types
+
+The `ConfigValueType` enum defines supported configuration value types with automatic casting.
+
+## Supported Types
+
+| Enum Case | Database Type | PHP Return Type | Description |
+|-----------|---------------|-----------------|-------------|
+| `String` | `'string'` | `string` | Plain text |
+| `Integer` | `'int'` | `int` | Whole numbers |
+| `Float` | `'float'` | `float` | Decimal numbers |
+| `Boolean` | `'bool'` | `bool` | True/false |
+| `Array` | `'array'` | `array` | Indexed/associative arrays |
+| `Json` | `'json'` | `mixed` | Complex objects (stored as JSON) |
+| `Date` | `'date'` | `Carbon|null` | DateTime objects |
+
+## Usage Examples
+
+```php
+use Whilesmart\ModelConfiguration\Enums\ConfigValueType;
+
+$user->setConfigValue('name', 'John', ConfigValueType::String);
+$user->setConfigValue('age', 30, ConfigValueType::Integer);
+$user->setConfigValue('rating', 4.5, ConfigValueType::Float);
+$user->setConfigValue('active', true, ConfigValueType::Boolean);
+$user->setConfigValue('tags', ['php', 'laravel'], ConfigValueType::Array);
+$user->setConfigValue('profile', ['bio' => 'Dev', 'avatar' => 'img.png'], ConfigValueType::Json);
+$user->setConfigValue('birthday', '1990-01-15', ConfigValueType::Date);
+```
+
+## Type Casting Behavior
+
+### String
+```php
+$user->setConfigValue('name', 123, ConfigValueType::String);
+$user->getConfigValue('name'); // "123" (string)
+```
+
+### Integer
+```php
+$user->setConfigValue('count', '42', ConfigValueType::Integer);
+$user->getConfigValue('count'); // 42 (int)
+
+$user->setConfigValue('count', 3.14, ConfigValueType::Integer);
+$user->getConfigValue('count'); // 3 (int)
+```
+
+### Float
+```php
+$user->setConfigValue('price', '19.99', ConfigValueType::Float);
+$user->getConfigValue('price'); // 19.99 (float)
+```
+
+### Boolean
+```php
+$user->setConfigValue('enabled', 'true', ConfigValueType::Boolean);
+$user->getConfigValue('enabled'); // true (bool)
+
+$user->setConfigValue('enabled', 1, ConfigValueType::Boolean);
+$user->getConfigValue('enabled'); // true (bool)
+
+$user->setConfigValue('enabled', 'false', ConfigValueType::Boolean);
+$user->getConfigValue('enabled'); // false (bool)
+```
+
+### Array
+```php
+$user->setConfigValue('colors', ['red', 'blue'], ConfigValueType::Array);
+$user->getConfigValue('colors'); // ['red', 'blue'] (array)
+
+$user->setConfigValue('settings', new Collection(['a' => 1]), ConfigValueType::Array);
+$user->getConfigValue('settings'); // ['a' => 1] (array)
+```
+
+### Json
+```php
+$user->setConfigValue('data', ['nested' => ['deep' => 'value']], ConfigValueType::Json);
+$user->getConfigValue('data'); // ['nested' => ['deep' => 'value']] (preserved structure)
+```
+
+### Date
+```php
+$user->setConfigValue('expires', '2025-12-31', ConfigValueType::Date);
+$user->getConfigValue('expires'); // Carbon instance
+
+$user->setConfigValue('expires', now()->addDays(30), ConfigValueType::Date);
+$user->getConfigValue('expires'); // Carbon instance
+
+// Invalid date returns null
+$user->setConfigValue('expires', 'not-a-date', ConfigValueType::Date);
+$user->getConfigValue('expires'); // null (with warning logged)
+```
+
+## Checking Types Programmatically
+
+```php
+$type = $user->getConfigType('age'); // ConfigValueType::Integer
+
+if ($type === ConfigValueType::Integer) {
+    // ...
+}
+
+// Get all type cases
+ConfigValueType::cases(); // [String, Integer, Float, Boolean, Array, Json, Date]
+```
+
+## Database Storage
+
+All values are stored as JSON in the `value` column. The `type` column stores the enum string (e.g., `'string'`, `'int'`).
+
+```sql
+-- configurations table
+id | key         | value              | type   | configurable_type      | configurable_id
+---|-------------|--------------------|--------|------------------------|----------------
+1  | timezone    | "America/NY"| "string"| App\Models\User      | 1
+2  | per_page    | 25                 | "int"  | App\Models\User      | 1
+3  | settings    | {"theme":"dark"}   | "json" | App\Models\User      | 1
+```


### PR DESCRIPTION
## Summary
Adds `docs.json` manifest and markdown documentation for the site at developers.whilesmart.com.

## Files Added
- `docs.json` — manifest with 8 sidebar entries
- `docs/installation.md` — Composer install, publish options, route registration, auth middleware
- `docs/quick-start.md` — 5-step guide: add trait → migrate → set/get values → API usage
- `docs/configuration.md` — Full config reference: route prefix, auth, case-insensitive keys, allowed keys, custom model, hooks
- `docs/configurable-trait.md` — All 7 trait methods with examples
- `docs/value-types.md` — All 7 ConfigValueType cases with casting behavior
- `docs/api-endpoints.md` — 5 REST endpoints with params, request/response examples, OpenAPI
- `docs/hooks.md` — Both hook interfaces, registration, use cases, audit log example
- `docs/custom-models.md` — Extending Configuration model (soft deletes, auditing, custom traits)

## Testing
- `docs.json` validates against schema
- All referenced markdown files exist
- Package will appear on /packages listing with docs rendering

Closes #45